### PR TITLE
change ubuntu dependencies in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ with new modules.
 
 You might need following dependencies (Ubuntu Linux):
 
-    sudo apt install libjack0 libjack-dev libx11-xcb-dev libxcb-icccm4-dev libxcb-dri3-dev
+    sudo apt install libjack0 libjack-jackd2-dev qjackctl libx11-xcb-dev libxcb-icccm4-dev libxcb-dri3-dev
 
 ## Running the Automated Testsuite:
 


### PR DESCRIPTION
I had to remove `libjack-dev` and replace with `libjack-jackd2-dev` and got the rest of the jack deps with `qjackctl`