### PR TITLE
Documentation and DspNode trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ with new modules.
 
 You might need following dependencies (Ubuntu Linux):
 
-    sudo apt install libjack0 libjack-dev libx11-xcb-dev libxcb-icccm4-dev libxcb-dri3-dev
+    sudo apt install libjack0 libjack-jackd2-dev qjackctl libx11-xcb-dev libxcb-icccm4-dev libxcb-dri3-dev
 
 ## Running the Automated Testsuite:
 

--- a/src/dsp/helpers.rs
+++ b/src/dsp/helpers.rs
@@ -136,10 +136,12 @@ pub fn note_to_freq(note: f32) -> f32 {
 // * DspEffectLibrary.h - library with template-based inline-effects
 // * Copyright (c) 2006-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
 //
-// Signal distortion
-// gain:        0.1 - 5.0       default = 1.0
-// threshold:   0.0 - 100.0     default = 0.8
-// i:           signal
+/// Signal distortion
+/// ```ignore
+/// gain:        0.1 - 5.0       default = 1.0
+/// threshold:   0.0 - 100.0     default = 0.8
+/// i:           signal
+/// ```
 pub fn f_distort(gain: f32, threshold: f32, i: f32) -> f32 {
     gain * (
         i * ( i.abs() + threshold )
@@ -150,10 +152,12 @@ pub fn f_distort(gain: f32, threshold: f32, i: f32) -> f32 {
 // * DspEffectLibrary.h - library with template-based inline-effects
 // * Copyright (c) 2006-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
 //
-// Foldback Signal distortion
-// gain:        0.1 - 5.0       default = 1.0
-// threshold:   0.0 - 100.0     default = 0.8
-// i:           signal
+/// Foldback Signal distortion
+/// ```ignore
+/// gain:        0.1 - 5.0       default = 1.0
+/// threshold:   0.0 - 100.0     default = 0.8
+/// i:           signal
+/// ```
 pub fn f_fold_distort(gain: f32, threshold: f32, i: f32) -> f32 {
     if i >= threshold || i < -threshold {
         gain
@@ -201,7 +205,9 @@ pub fn range2p_exp4(v: f32, a: f32, b: f32) -> f32 {
     (((v - a) / (b - a)).abs()).sqrt().sqrt()
 }
 
-// gain: 24.0 - -90.0   default = 0.0
+/// ```ignore
+/// gain: 24.0 - -90.0   default = 0.0
+/// ```
 pub fn gain2coef(gain: f32) -> f32 {
     if gain > -90.0 {
         10.0_f32.powf(gain * 0.05)

--- a/src/dsp/mod.rs
+++ b/src/dsp/mod.rs
@@ -23,6 +23,19 @@ pub const MIDI_MAX_FREQ : f32 = 13289.75;
 
 pub const MAX_BLOCK_SIZE : usize = 64;
 
+pub trait DspNode {
+    /// number of outputs this node supports
+    fn outputs() -> usize;
+
+    fn set_sample_rate(&mut self, _srate: f32);
+
+    fn reset(&mut self);
+
+    fn process<T: NodeAudioContext>(
+        &mut self, ctx: &mut T, _atoms: &[SAtom], _params: &[ProcBuf],
+        inputs: &[ProcBuf], outputs: &mut [ProcBuf]);
+}
+
 /// A processing buffer with the exact right maximum size.
 #[derive(Clone, Copy)]
 pub struct ProcBuf(*mut [f32; MAX_BLOCK_SIZE]);

--- a/src/dsp/node_amp.rs
+++ b/src/dsp/node_amp.rs
@@ -1,5 +1,5 @@
 use crate::nodes::NodeAudioContext;
-use crate::dsp::{SAtom, ProcBuf};
+use crate::dsp::{SAtom, ProcBuf, DspNode};
 
 /// A simple amplifier
 #[derive(Debug, Clone)]
@@ -7,18 +7,26 @@ pub struct Amp {
 }
 
 impl Amp {
-    pub fn outputs() -> usize { 1 }
-
     pub fn new() -> Self {
         Self {
         }
     }
+    pub const inp : &'static str =
+        "Amp inp\nSignal input\nRange: (-1..1)\n";
+    pub const gain : &'static str =
+        "Amp gain\nGain input\nRange: (0..1)\n";
+    pub const sig : &'static str =
+        "Amp sig\nAmplified signal output\nRange: (-1..1)\n";
+}
 
-    pub fn set_sample_rate(&mut self, _srate: f32) { }
-    pub fn reset(&mut self) { }
+impl DspNode for Amp {
+    fn outputs() -> usize { 1 }
+
+    fn set_sample_rate(&mut self, _srate: f32) { }
+    fn reset(&mut self) { }
 
     #[inline]
-    pub fn process<T: NodeAudioContext>(
+    fn process<T: NodeAudioContext>(
         &mut self, ctx: &mut T, _atoms: &[SAtom], _params: &[ProcBuf],
         inputs: &[ProcBuf], outputs: &mut [ProcBuf])
     {
@@ -33,11 +41,4 @@ impl Amp {
             out.write(frame, inp.read(frame) * denorm::Amp::gain(gain, frame));
         }
     }
-
-    pub const inp : &'static str =
-        "Amp inp\nSignal input\nRange: (-1..1)\n";
-    pub const gain : &'static str =
-        "Amp gain\nGain input\nRange: (0..1)\n";
-    pub const sig : &'static str =
-        "Amp sig\nAmplified signal output\nRange: (-1..1)\n";
 }

--- a/src/dsp/node_out.rs
+++ b/src/dsp/node_out.rs
@@ -1,5 +1,5 @@
 use crate::nodes::NodeAudioContext;
-use crate::dsp::{SAtom, ProcBuf, inp, at};
+use crate::dsp::{SAtom, ProcBuf, DspNode, inp, at};
 
 /// The (stereo) output port of the plugin
 #[derive(Debug, Clone)]
@@ -8,40 +8,12 @@ pub struct Out {
     /// - 1: signal channel 2
     input:  [f32; 2],
 }
-
 impl Out {
-    pub fn outputs() -> usize { 0 }
-
     pub fn new() -> Self {
         Self {
             input:  [0.0; 2],
         }
     }
-
-    pub fn set_sample_rate(&mut self, _srate: f32) { }
-    pub fn reset(&mut self) { }
-
-    #[inline]
-    pub fn process<T: NodeAudioContext>(
-        &mut self, ctx: &mut T, atoms: &[SAtom], _params: &[ProcBuf],
-        inputs: &[ProcBuf], _outputs: &mut [ProcBuf])
-    {
-        if at::Out::mono(atoms).i() > 0 {
-            let in1 = inp::Out::ch1(inputs);
-            for frame in 0..ctx.nframes() {
-                ctx.output(0, frame, in1.read(frame));
-                ctx.output(1, frame, in1.read(frame));
-            }
-        } else {
-            let in1 = inp::Out::ch1(inputs);
-            let in2 = inp::Out::ch2(inputs);
-            for frame in 0..ctx.nframes() {
-                ctx.output(0, frame, in1.read(frame));
-                ctx.output(1, frame, in2.read(frame));
-            }
-        }
-    }
-
     pub const mono : &'static str =
         "Out mono\nIf enabled, ch1 will be sent to both output channels\n(UI only)";
 
@@ -65,4 +37,32 @@ impl Out {
     pub const ch15: &'static str = "Out ch2\nAudio channel 2 (right)\nRange: (-1..1)";
     pub const ch16: &'static str = "Out ch2\nAudio channel 2 (right)\nRange: (-1..1)";
     pub const ch17: &'static str = "Out ch2\nAudio channel 2 (right)\nRange: (-1..1)";
+}
+
+impl DspNode for Out {
+    fn outputs() -> usize { 0 }
+
+    fn set_sample_rate(&mut self, _srate: f32) { }
+    fn reset(&mut self) { }
+
+    #[inline]
+    fn process<T: NodeAudioContext>(
+        &mut self, ctx: &mut T, atoms: &[SAtom], _params: &[ProcBuf],
+        inputs: &[ProcBuf], _outputs: &mut [ProcBuf])
+    {
+        if at::Out::mono(atoms).i() > 0 {
+            let in1 = inp::Out::ch1(inputs);
+            for frame in 0..ctx.nframes() {
+                ctx.output(0, frame, in1.read(frame));
+                ctx.output(1, frame, in1.read(frame));
+            }
+        } else {
+            let in1 = inp::Out::ch1(inputs);
+            let in2 = inp::Out::ch2(inputs);
+            for frame in 0..ctx.nframes() {
+                ctx.output(0, frame, in1.read(frame));
+                ctx.output(1, frame, in2.read(frame));
+            }
+        }
+    }
 }

--- a/src/dsp/node_sin.rs
+++ b/src/dsp/node_sin.rs
@@ -1,5 +1,5 @@
 use crate::nodes::NodeAudioContext;
-use crate::dsp::{SAtom, ProcBuf, denorm, out, inp};
+use crate::dsp::{SAtom, ProcBuf, DspNode, denorm, out, inp};
 use crate::dsp::helpers::fast_sin;
 
 
@@ -15,25 +15,31 @@ pub struct Sin {
 const TWOPI : f32 = 2.0 * std::f32::consts::PI;
 
 impl Sin {
-    pub fn outputs() -> usize { 1 }
-
     pub fn new() -> Self {
         Self {
             srate: 44100.0,
             phase: 0.0,
         }
     }
+    pub const freq : &'static str =
+        "Sin freq\nFrequency of the oscillator.\n\nRange: (-1..1)\n";
+    pub const sig : &'static str =
+        "Sin sig\nOscillator signal output.\n\nRange: (-1..1)\n";
+}
 
-    pub fn set_sample_rate(&mut self, srate: f32) {
+impl DspNode for Sin {
+    fn outputs() -> usize { 1 }
+
+    fn set_sample_rate(&mut self, srate: f32) {
         self.srate = srate;
     }
 
-    pub fn reset(&mut self) {
+    fn reset(&mut self) {
         self.phase = 0.0;
     }
 
     #[inline]
-    pub fn process<T: NodeAudioContext>(
+    fn process<T: NodeAudioContext>(
         &mut self, ctx: &mut T, _atoms: &[SAtom], _params: &[ProcBuf],
         inputs: &[ProcBuf], outputs: &mut [ProcBuf])
     {
@@ -51,8 +57,5 @@ impl Sin {
         }
     }
 
-    pub const freq : &'static str =
-        "Sin freq\nFrequency of the oscillator.\n\nRange: (-1..1)\n";
-    pub const sig : &'static str =
-        "Sin sig\nOscillator signal output.\n\nRange: (-1..1)\n";
+    
 }

--- a/src/dsp/node_test.rs
+++ b/src/dsp/node_test.rs
@@ -1,5 +1,5 @@
 use crate::nodes::NodeAudioContext;
-use crate::dsp::{SAtom, ProcBuf};
+use crate::dsp::{SAtom, ProcBuf, DspNode};
 
 /// A simple amplifier
 #[derive(Debug, Clone)]
@@ -7,18 +7,26 @@ pub struct Test {
 }
 
 impl Test {
-    pub fn outputs() -> usize { 1 }
-
     pub fn new() -> Self {
         Self {
         }
     }
+    pub const f : &'static str = "F Test";
+    pub const s : &'static str = "S Test";
+//  pub const gain : &'static str =
+//      "Amp gain\nGain input\nRange: (0..1)\n";
+//  pub const sig : &'static str =
+//      "Amp sig\nAmplified signal output\nRange: (-1..1)\n";
+}
 
-    pub fn set_sample_rate(&mut self, _srate: f32) { }
-    pub fn reset(&mut self) { }
+impl DspNode for Test {
+    fn outputs() -> usize { 1 }
+
+    fn set_sample_rate(&mut self, _srate: f32) { }
+    fn reset(&mut self) { }
 
     #[inline]
-    pub fn process<T: NodeAudioContext>(
+    fn process<T: NodeAudioContext>(
         &mut self, ctx: &mut T, _atoms: &[SAtom], _params: &[ProcBuf],
         inputs: &[ProcBuf], outputs: &mut [ProcBuf])
     {
@@ -34,11 +42,4 @@ impl Test {
 //        }
     }
 
-    pub const f : &'static str = "F Test";
-    pub const s : &'static str = "S Test";
-
-//    pub const gain : &'static str =
-//        "Amp gain\nGain input\nRange: (0..1)\n";
-//    pub const sig : &'static str =
-//        "Amp sig\nAmplified signal output\nRange: (-1..1)\n";
 }


### PR DESCRIPTION
this pr 
- switches some comments to doc comments along with formatting them a little for easier reading in an IDE
- changes some ubuntu dependencies in readme.md that didn't work for me
- adds a trait for dsp nodes to allow common documentation on those, and to statically ensure we can't forget a method

```rust
pub trait DspNode {
    /// number of outputs this node supports
    fn outputs() -> usize;

    fn set_sample_rate(&mut self, _srate: f32);

    fn reset(&mut self);

    fn process<T: NodeAudioContext>(
        &mut self, ctx: &mut T, _atoms: &[SAtom], _params: &[ProcBuf],
        inputs: &[ProcBuf], outputs: &mut [ProcBuf]);
}
```
